### PR TITLE
Express API special handling no longer necessary

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,13 +40,7 @@ In order to run the tests execute:
 npm test
 ```
 
-**Note:** Returned error codes from [Express](https://auth0.com/docs/quickstart/backend/nodejs) and [Symfony](https://auth0.com/docs/quickstart/backend/symfony) API are different from the standard. For that cases execute:
-
-To test Express API quickstart:
-
-```bash
-quickstart="express" npm test
-```
+**Note:** Returned error codes from the [Symfony](https://auth0.com/docs/quickstart/backend/symfony) and [Spring Webflux](https://github.com/auth0-samples/auth0-spring-security5-api-sample/tree/master/01-Authorization-WebFlux) API are different from the standard. For those cases execute:
 
 To test Symfony API quickstart:
 

--- a/test/test.js
+++ b/test/test.js
@@ -56,11 +56,6 @@ switch(process.env.quickstart) {
     expectedErrorCodes['token_with_invalid_signature_private'] = 500;
     expectedErrorCodes['token_with_invalid_signature_private_scoped'] = 500;
     break;
-  case 'express':
-    // Error codes returned by Node.js Express API quickstart
-    expectedErrorCodes['token_without_scope_private_scoped'] = 401;
-    expectedErrorCodes['token_with_scope_write:messages_private_scoped'] = 401;
-    break;
   case 'spring5-webflux':
     // Error codes returned by Spring 5 WebFlux API quickstart
     expectedErrorCodes['authorization_header_with_value_Bearer_invalidToken_abc_private'] = 500;


### PR DESCRIPTION
`express-jwt-authz` now returns `403` for insufficient scopes. CircleCI is currently [configured](https://github.com/auth0-samples/auth0-express-api-samples/blob/master/.circleci/config.yml#L52) to not run with the express flag, so this isn't used at all.