### PR TITLE
Remove Spring WebFlux Special Error Code Handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,16 +40,9 @@ In order to run the tests execute:
 npm test
 ```
 
-**Note:** Returned error codes from the [Symfony](https://auth0.com/docs/quickstart/backend/symfony) and [Spring Webflux](https://github.com/auth0-samples/auth0-spring-security5-api-sample/tree/master/01-Authorization-WebFlux) API are different from the standard. For those cases execute:
+**Note:** Returned error codes from the [Symfony](https://auth0.com/docs/quickstart/backend/symfony) API are different from the standard. For those cases execute:
 
-To test Symfony API quickstart:
 
 ```bash
 quickstart="symfony" npm test
-```
-
-To test Spring 5 WebFlux API quickstart:
-
-```bash
-quickstart="spring5-webflux" npm test
 ```

--- a/test/test.js
+++ b/test/test.js
@@ -40,28 +40,19 @@ let expectedErrorCodes = {
   'token_with_scope_write:messages_private_scoped': 403,
 }
 
-switch(process.env.quickstart) {
-  case 'symfony':
-    // Error codes returned by Symfony API quickstart
-    expectedErrorCodes['request_without_authorization_header_private'] = 403;
-    expectedErrorCodes['request_without_authorization_header_private_scoped'] = 403;
-    expectedErrorCodes['authorization_header_with_value_Bearer_private'] = 500;
-    expectedErrorCodes['authorization_header_with_value_Bearer_private_scoped'] = 500;
-    expectedErrorCodes['authorization_header_with_empty_value_private'] = 403;
-    expectedErrorCodes['authorization_header_with_empty_value_private_scoped'] = 403;
-    expectedErrorCodes['authorization_header_with_value_Bearer_invalidToken_private'] = 500;
-    expectedErrorCodes['authorization_header_with_value_Bearer_invalidToken_private_scoped'] = 500;
-    expectedErrorCodes['authorization_header_with_value_Bearer_invalidToken_abc_private'] = 500;
-    expectedErrorCodes['authorization_header_with_value_Bearer_invalidToken_abc_private_scoped'] = 500;
-    expectedErrorCodes['token_with_invalid_signature_private'] = 500;
-    expectedErrorCodes['token_with_invalid_signature_private_scoped'] = 500;
-    break;
-  case 'spring5-webflux':
-    // Error codes returned by Spring 5 WebFlux API quickstart
-    expectedErrorCodes['authorization_header_with_value_Bearer_invalidToken_abc_private'] = 500;
-    expectedErrorCodes['authorization_header_with_value_Bearer_invalidToken_abc_private_scoped'] = 500;
-    expectedErrorCodes['authorization_header_with_value_Bearer_private'] = 500;
-    expectedErrorCodes['authorization_header_with_value_Bearer_private_scoped'] = 500;
+if (process.env.quickstart === 'symfony') {
+  expectedErrorCodes['request_without_authorization_header_private'] = 403;
+  expectedErrorCodes['request_without_authorization_header_private_scoped'] = 403;
+  expectedErrorCodes['authorization_header_with_value_Bearer_private'] = 500;
+  expectedErrorCodes['authorization_header_with_value_Bearer_private_scoped'] = 500;
+  expectedErrorCodes['authorization_header_with_empty_value_private'] = 403;
+  expectedErrorCodes['authorization_header_with_empty_value_private_scoped'] = 403;
+  expectedErrorCodes['authorization_header_with_value_Bearer_invalidToken_private'] = 500;
+  expectedErrorCodes['authorization_header_with_value_Bearer_invalidToken_private_scoped'] = 500;
+  expectedErrorCodes['authorization_header_with_value_Bearer_invalidToken_abc_private'] = 500;
+  expectedErrorCodes['authorization_header_with_value_Bearer_invalidToken_abc_private_scoped'] = 500;
+  expectedErrorCodes['token_with_invalid_signature_private'] = 500;
+  expectedErrorCodes['token_with_invalid_signature_private_scoped'] = 500;
 }
 
 const getToken = function(clientId, clientSecret) {


### PR DESCRIPTION
After upgrading to the latest Spring Boot (https://github.com/auth0-samples/auth0-spring-security5-api-sample/pull/13), we no longer need special handling for some error codes when running with WebFlux. This change removes that special-case handling.