### PR TITLE
Remove asyncawait dependency and use native async/await

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,6 @@
   "packages": {
     "": {
       "dependencies": {
-        "asyncawait": "^3.0.0",
         "chai": "^4.3.4",
         "chai-http": "^4.3.0",
         "dotenv": "^10.0.0",
@@ -97,16 +96,6 @@
         "node": "*"
       }
     },
-    "node_modules/asyncawait": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/asyncawait/-/asyncawait-3.0.0.tgz",
-      "integrity": "sha512-dkB1xxfmIX3smmQiZHRfgD1m9Ggm9tkT162Q9wZzhW6RLOoO3VWTgNDZ0E3UwzqoypMmz9kMxdVd9u9mh8yXlA==",
-      "dependencies": {
-        "bluebird": "^3.1.1",
-        "fibers": "^4.0.2",
-        "lodash": "^4.17.12"
-      }
-    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -124,11 +113,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/bluebird": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
-      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
@@ -400,17 +384,6 @@
         "node": ">=0.4.0"
       }
     },
-    "node_modules/detect-libc": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-      "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
-      "bin": {
-        "detect-libc": "bin/detect-libc.js"
-      },
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
     "node_modules/diff": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
@@ -455,18 +428,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
-    },
-    "node_modules/fibers": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/fibers/-/fibers-4.0.3.tgz",
-      "integrity": "sha512-MW5VrDtTOLpKK7lzw4qD7Z9tXaAhdOmOED5RHzg3+HjUk+ibkjVW0Py2ERtdqgTXaerLkVkBy2AEmJiT6RMyzg==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "detect-libc": "^1.0.3"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
     },
     "node_modules/fill-range": {
       "version": "7.0.1",
@@ -783,11 +744,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/log-symbols": {
       "version": "4.1.0",
@@ -1460,16 +1416,6 @@
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
       "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw=="
     },
-    "asyncawait": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/asyncawait/-/asyncawait-3.0.0.tgz",
-      "integrity": "sha512-dkB1xxfmIX3smmQiZHRfgD1m9Ggm9tkT162Q9wZzhW6RLOoO3VWTgNDZ0E3UwzqoypMmz9kMxdVd9u9mh8yXlA==",
-      "requires": {
-        "bluebird": "^3.1.1",
-        "fibers": "^4.0.2",
-        "lodash": "^4.17.12"
-      }
-    },
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -1484,11 +1430,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA=="
-    },
-    "bluebird": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
-      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -1699,11 +1640,6 @@
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
-    "detect-libc": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-      "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups="
-    },
     "diff": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
@@ -1733,14 +1669,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
-    },
-    "fibers": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/fibers/-/fibers-4.0.3.tgz",
-      "integrity": "sha512-MW5VrDtTOLpKK7lzw4qD7Z9tXaAhdOmOED5RHzg3+HjUk+ibkjVW0Py2ERtdqgTXaerLkVkBy2AEmJiT6RMyzg==",
-      "requires": {
-        "detect-libc": "^1.0.3"
-      }
     },
     "fill-range": {
       "version": "7.0.1",
@@ -1957,11 +1885,6 @@
       "requires": {
         "p-locate": "^5.0.0"
       }
-    },
-    "lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "log-symbols": {
       "version": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "dependencies": {
-    "asyncawait": "^3.0.0",
     "chai": "^4.3.4",
     "chai-http": "^4.3.0",
     "dotenv": "^10.0.0",

--- a/test/test.js
+++ b/test/test.js
@@ -1,8 +1,6 @@
 const chai = require('chai');
 const chaiHttp = require('chai-http');
 const should = require('chai').should();
-const async = require('asyncawait/async');
-const await = require('asyncawait/await');
 
 require('dotenv').config();
 
@@ -191,13 +189,13 @@ describe('Request with authorization header field', function() {
   context('Token with invalid signature', function() {
     let validToken = null;
 
-    before(async(function() {
+    before(async function() {
       let clientId = process.env.AUTH0_CLIENT_ID_1;
       let clientSecret = process.env.AUTH0_CLIENT_SECRET_1;
 
       const token =  await(getToken(clientId, clientSecret));
       validToken = token.body.access_token;
-    }));
+    });
 
     it('GET /api/private return ' + expectedErrorCodes['token_with_invalid_signature_private'] + ' Unauthorized', function(done) {
       chai.request(apiURL)
@@ -223,13 +221,13 @@ describe('Request with authorization header field', function() {
   context('Valid token without any scope', function() {
     let validToken = null;
     
-    before(async(function() {
+    before(async function() {
       let clientId = process.env.AUTH0_CLIENT_ID_1;
       let clientSecret = process.env.AUTH0_CLIENT_SECRET_1;
 
       const token =  await(getToken(clientId, clientSecret));
       validToken = token.body.access_token;
-    }));
+    });
 
     it('GET /api/private return 200 OK', function(done) {
       chai.request(apiURL)
@@ -254,13 +252,13 @@ describe('Request with authorization header field', function() {
   });
 
   context('Valid token with read:messages scope', function() {
-    before(async(function() {
+    before(async function() {
       let clientId = process.env.AUTH0_CLIENT_ID_2;
       let clientSecret = process.env.AUTH0_CLIENT_SECRET_2;
 
       const token =  await(getToken(clientId, clientSecret));
       validToken = token.body.access_token;
-    }));
+    });
 
     it('GET /api/private return 200 OK', function(done) {
       chai.request(apiURL)
@@ -286,13 +284,13 @@ describe('Request with authorization header field', function() {
   });
 
   context('Valid token with write:messages scope', function() {
-    before(async(function() {
+    before(async function() {
       let clientId = process.env.AUTH0_CLIENT_ID_3;
       let clientSecret = process.env.AUTH0_CLIENT_SECRET_3;
 
       const token =  await(getToken(clientId, clientSecret));
       validToken = token.body.access_token;
-    }));
+    });
 
     it('GET /api/private return 200 OK', function(done) {
       chai.request(apiURL)
@@ -317,13 +315,13 @@ describe('Request with authorization header field', function() {
   });
 
   context('Valid token with read:messages and write:messages scopes', function() {
-    before(async(function() {
+    before(async function() {
       let clientId = process.env.AUTH0_CLIENT_ID_4;
       let clientSecret = process.env.AUTH0_CLIENT_SECRET_4;
 
       const token =  await(getToken(clientId, clientSecret));
       validToken = token.body.access_token;
-    }));
+    });
 
     it('GET /api/private return 200 OK', function(done) {
       chai.request(apiURL)


### PR DESCRIPTION
This should fix issues with newer node versions.

MDN [claims support](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function#browser_compatibility) since Node 7.6.0, so this should be safe for any consumers. But I've created a [v0.0.2](https://github.com/auth0-samples/api-quickstarts-tests/tree/v0.0.2) tag that we can use if any issues arise after merge